### PR TITLE
Add `chosen-select` class to `filter_date()` select

### DIFF
--- a/classes/class-list-table.php
+++ b/classes/class-list-table.php
@@ -772,7 +772,7 @@ class List_Table extends \WP_List_Table {
 		?>
 		<div class="date-interval">
 
-			<select class="field-predefined hide-if-no-js" name="date_predefined" data-placeholder="<?php esc_attr_e( 'All Time', 'stream' ) ?>">
+			<select class="field-predefined hide-if-no-js chosen-select" name="date_predefined" data-placeholder="<?php esc_attr_e( 'All Time', 'stream' ) ?>">
 				<option></option>
 				<option value="custom" <?php selected( 'custom' === $date_predefined ); ?>><?php esc_attr_e( 'Custom', 'stream' ) ?></option>
 				<?php


### PR DESCRIPTION
Stream uses the `chosen-select` class in its `select` element creation & Select2 implementation, but it's missing on this dropdown.

I found this trying to avoid conflicts with my WP Chosen plugin. I'm able to use the `chosen-select` class to do this, everywhere but this one place.

See: https://github.com/stuttter/wp-chosen/issues/7